### PR TITLE
bump graphql to 22.2, compile fixes, test updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.classpath
 /.project
 .settings
+.idea/*
+

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<jackson.version>2.15.2</jackson.version>
 		<pitest.version>1.9.0</pitest.version>
 		<pitest-junit5-plugin.version>1.0.0</pitest-junit5-plugin.version>
-		<graphql.version>21.1</graphql.version>
+		<graphql.version>22.2</graphql.version>
 	</properties>
 
 	<distributionManagement>

--- a/src/main/java/com/fleetpin/graphql/builder/mapper/ObjectFieldBuilder.java
+++ b/src/main/java/com/fleetpin/graphql/builder/mapper/ObjectFieldBuilder.java
@@ -14,7 +14,6 @@ package com.fleetpin.graphql.builder.mapper;
 import com.fleetpin.graphql.builder.EntityProcessor;
 import com.fleetpin.graphql.builder.TypeMeta;
 import graphql.GraphQLContext;
-import graphql.com.google.common.base.Throwables;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -44,7 +43,6 @@ public class ObjectFieldBuilder implements InputTypeBuilder {
 
 						return toReturn;
 					} catch (Throwable e) {
-						Throwables.throwIfUnchecked(e);
 						throw new RuntimeException(e);
 					}
 				};

--- a/src/main/java/com/fleetpin/graphql/builder/mapper/ObjectFieldBuilder.java
+++ b/src/main/java/com/fleetpin/graphql/builder/mapper/ObjectFieldBuilder.java
@@ -14,6 +14,8 @@ package com.fleetpin.graphql.builder.mapper;
 import com.fleetpin.graphql.builder.EntityProcessor;
 import com.fleetpin.graphql.builder.TypeMeta;
 import graphql.GraphQLContext;
+import graphql.com.google.common.base.Preconditions;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -43,6 +45,7 @@ public class ObjectFieldBuilder implements InputTypeBuilder {
 
 						return toReturn;
 					} catch (Throwable e) {
+						throwIfUnchecked(e);
 						throw new RuntimeException(e);
 					}
 				};
@@ -82,6 +85,16 @@ public class ObjectFieldBuilder implements InputTypeBuilder {
 
 		public static FieldMapper build(EntityProcessor entityProcessor, TypeMeta inputType, String name, Method method) {
 			return new FieldMapper(name, method, entityProcessor.getResolver(inputType));
+		}
+	}
+
+	// copied from guava
+	public static void throwIfUnchecked(Throwable throwable) {
+		Preconditions.checkNotNull(throwable);
+		if (throwable instanceof RuntimeException) {
+			throw (RuntimeException)throwable;
+		} else if (throwable instanceof Error) {
+			throw (Error)throwable;
 		}
 	}
 }

--- a/src/test/java/com/fleetpin/graphql/builder/DirectiveTest.java
+++ b/src/test/java/com/fleetpin/graphql/builder/DirectiveTest.java
@@ -87,7 +87,7 @@ public class DirectiveTest {
 		List<LinkedHashMap<String, Object>> dir = (List<LinkedHashMap<String, Object>>) ((Map<String, Object>) response.get("__schema")).get("directives");
 		LinkedHashMap<String, Object> input = dir.stream().filter(map -> map.get("name").equals("Input")).collect(Collectors.toList()).get(0);
 
-		assertEquals(7, dir.size());
+		assertEquals(8, dir.size());
 		assertEquals("ARGUMENT_DEFINITION", ((List<String>) input.get("locations")).get(0));
 		assertEquals(1, ((List<Object>) input.get("args")).size());
 		//getNickname(nickName: String! @Input(value : "TT")): String!


### PR DESCRIPTION
Hoping it fixes discrepancy with `@GraphQLDescription` annotations not being pulled through in resolved supergraph.